### PR TITLE
Fix incorrect base64 decoding of files from database (Fixes #12)

### DIFF
--- a/web/src/components/SourceFilesView/sourceFilesView.js
+++ b/web/src/components/SourceFilesView/sourceFilesView.js
@@ -96,8 +96,13 @@ class SourceFilesView extends Component {
     return (event) => {
       const {sourceFiles} = this.state;
       if (sourceFiles[fileName] && sourceFiles[fileName].data) {
-        const file = new File([atob(sourceFiles[fileName].data)], fileName, {type: "text/plain;charset=utf-8"});
-        saveAs(file);
+        const binaryString = atob(sourceFiles[fileName].data);
+        const byteArray = new Uint8Array(binaryString.length);
+        for (let index = 0; index < binaryString.length; index++) {
+          byteArray[index] = binaryString.charCodeAt(index);
+        }
+        const file = new Blob([byteArray]);
+        saveAs(file, fileName);
       } else {
         this.setState({
           error: `Unable to download file "${fileName}"`

--- a/web/src/components/SourceFilesView/sourceFilesView.test.js
+++ b/web/src/components/SourceFilesView/sourceFilesView.test.js
@@ -68,7 +68,7 @@ describe('SourceFilesView', () => {
       wrapper.update().find('[test-attr="down-btn-hello_world.py"]').simulate('click');
       await tick();
 
-      expect(saveAs).toHaveBeenCalledWith(new File([atob(responseData[0].chunk[0].data)], files[0].name));
+      expect(saveAs).toHaveBeenCalledWith(new Blob([atob(responseData[0].chunk[0].data)]), files[0].name);
     });
 
     it('display error when source does not exist', async () => {


### PR DESCRIPTION
Hi,

I have fixed the issue reported by me a couple of days ago (#12). Just to clarify: the bug caused any kind of binary data (non-textual data, so everything was fine with e.g. source code) to become corrupted during base64 decoding from fs.chunks. This was caused by the browser treating decoded bytes incorrectly. More on that on [MDN](https://developer.mozilla.org/en-US/docs/Web/API/WindowBase64/Base64_encoding_and_decoding#The_Unicode_Problem). I've came up with a simple solution and this appears to work both for downloading textual and binary data.

Please let me know if there's anything unclear or worth changing. Thanks.