### PR TITLE
Initialize notes field with sacred comment.

### DIFF
--- a/web/src/components/RunsTable/runsTable.js
+++ b/web/src/components/RunsTable/runsTable.js
@@ -111,7 +111,7 @@ class RunsTable extends Component {
       axios.get('/api/v1/Runs', {
         params: {
           select: '_id,heartbeat,experiment,command,artifacts,host,stop_time,config,' +
-          'result,start_time,resources,format,status,omniboard,metrics',
+          'result,start_time,resources,format,status,omniboard,metrics,meta',
           sort: '-_id',
           query: queryString,
           populate: 'metrics'
@@ -157,6 +157,16 @@ class RunsTable extends Component {
             if (data['status'] === STATUS.RUNNING && (new Date() - new Date(data['heartbeat']) > 120000)) {
               data['status'] = STATUS.PROBABLY_DEAD;
             }
+          }
+
+          // If a comment exist, add it to notes field.
+          if ('meta' in data) {
+            const meta = data['meta']
+            var comment = ''
+            if ('comment' in meta) {
+              comment = meta['comment']
+            }
+            data = {...data, 'notes': comment}
           }
 
           // Expand omniboard columns

--- a/web/src/components/RunsTable/runsTable.js
+++ b/web/src/components/RunsTable/runsTable.js
@@ -159,21 +159,24 @@ class RunsTable extends Component {
             }
           }
 
-          // If a comment exist, add it to notes field.
-          if ('meta' in data) {
-            const meta = data['meta']
-            var comment = ''
-            if ('comment' in meta) {
-              comment = meta['comment']
-            }
-            data = {...data, 'notes': comment}
-          }
 
           // Expand omniboard columns
           if ('omniboard' in data) {
             const omniboard = data['omniboard'];
             delete data['omniboard'];
             data = {...data, ...omniboard};
+          }
+
+          // Add notes from comment if none has been saved in omniboard
+          if (!('notes' in data)) {
+            if ('meta' in data) {
+              const meta = data['meta'];
+              delete data['meta']
+              if ('comment' in meta) {
+                const comment = meta['comment'];
+                data = {...data, 'notes': comment}
+              }
+            }
           }
 
           // Include metric columns

--- a/web/src/components/RunsTable/runsTable.test.js
+++ b/web/src/components/RunsTable/runsTable.test.js
@@ -59,7 +59,7 @@ describe('RunsTable', () => {
       return ['/api/v1/Runs', {
         params: {
           select: '_id,heartbeat,experiment,command,artifacts,host,stop_time,config,' +
-            'result,start_time,resources,format,status,omniboard,metrics',
+            'result,start_time,resources,format,status,omniboard,metrics,meta',
           sort: '-_id',
           query: queryString,
           populate: 'metrics'


### PR DESCRIPTION
Sacred has the ability to add a comment to a run through command line with -c. It is helpful to me to see that comment in sacred. I assumed a nice place would be to initialize it into the notes field to allow further modifications.