### PR TITLE
Minimize docker image and docker build context file size

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,8 +1,10 @@
 # Dependency directories
-node_modules/
-dist/
-coverage/
-build/
+**/node_modules/
+**/dist/
+**/coverage/
+**/build/
 .dockerignore
 .gitignore
+.git
 README.md
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,29 @@
 # build environment
 FROM node:10.8.0 as builder
+
 RUN mkdir -p /usr/omniboard
 WORKDIR /usr/omniboard
-ENV PATH /usr/omniboard/node_modules/.bin:$PATH
-
-# grab tini for signal processing and zombie killing
-ENV TINI_VERSION v0.18.0
-ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
-RUN chmod +x /tini
-# Having "--" at the end will enable passing command line args to npm script
-ENTRYPOINT ["/tini", "--", "yarn", "run", "prod"]
+ENV PATH=/usr/omniboard/node_modules/.bin:$PATH GENERATE_SOURCEMAP=false
 
 # install yarn
 RUN npm install -g yarn
 
 COPY . /usr/omniboard
 
-WORKDIR /usr/omniboard
 RUN yarn install
 
 EXPOSE 9000
+
+FROM node:10-alpine
+
+WORKDIR /usr/omniboard
+
+# Having "--" at the end will enable passing command line args to npm script
+ENTRYPOINT ["npm", "run", "prod", "--"]
+
+ENV PATH /usr/omniboard/node_modules/.bin:$PATH
+
+COPY --from=builder /usr/omniboard/package.json /usr/omniboard/package.json
+COPY --from=builder /usr/omniboard/dist /usr/omniboard/dist
+COPY --from=builder /usr/omniboard/web/build /usr/omniboard/web/build
+RUN npm install --production && npm cache clean --force


### PR DESCRIPTION
? Select the type of change that you're committing: ci:       Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
? What is the scope of this change (e.g. component or file name)? (press enter to skip)
 docker
? Write a short, imperative tense description of the change:
 Improve docker build by including only nessecary source files, and minimize the final docker image size
? Provide a longer description of the change: (press enter to skip)
 
? Are there any breaking changes? Yes
? Describe the breaking changes:
 Requires docker version 17.05 or higher, for multistage build
? Does this change affect any open issues? No