### PR TITLE
fix(sourcefilescompareview): prevent crash with empty files in source…

### DIFF
--- a/web/src/components/SourceFilesCompareView/sourceFilesCompareView.js
+++ b/web/src/components/SourceFilesCompareView/sourceFilesCompareView.js
@@ -125,7 +125,7 @@ class SourceFilesCompareView extends Component {
                   // Response body is a ReadableStream
                   const reader = response.body.getReader();
                   // Result is concatenated Array Buffer
-                  let result = null;
+                  let result = new ArrayBuffer(0);
                   const onStreamDone = () => {
                     // Convert array buffer to string
                     fileContents[fileId] = new TextDecoder().decode(result);
@@ -200,7 +200,7 @@ class SourceFilesCompareView extends Component {
         <AccordionItemBody>
           {(source1.length > 0 || source2.length > 0) ?
             <ReactDiffViewer splitView oldValue={source1} newValue={source2}/> :
-            <div className='text-center'>Diffs of large files cannot be rendered.</div>}
+            <div className='text-center'>Diffs of large files cannot be rendered (or file is empty).</div>}
         </AccordionItemBody>
       </AccordionItem>
     );


### PR DESCRIPTION
In the SourceFilesCompareView, the view crashes if one of the compared files is empty. This occurs because a `result` variable is set to null, which is not a valid ArrayBuffer, but `done` is set to true immediately if a source file is empty. For me, this kind of error occurs because my source files contain some `__init__.py` files which are empty.

With this change, the crash is prevented. For empty files, the warning `Diffs of large files cannot be rendered` is shown, which is not actually correct, but I haven't figured out how to distinguish between empty files and an actual error due to large files. The warning message was thus adjusted to also explain this type of error.

should fix #224