### PR TITLE
fix issue where numeric values are passed as strings to $in operator

### DIFF
--- a/web/src/components/RunsTable/runsTable.js
+++ b/web/src/components/RunsTable/runsTable.js
@@ -260,10 +260,24 @@ class RunsTable extends Component {
         if (filter.disabled === true) {
           // ignore
         } else if (filter.operator === '$in') {
-          let orFilters = filter.value.map(buildQueryFilter('$eq', filter.name));
+          const value = filter.value.map(value => {
+            // Check if the value is a number or boolean and convert type accordingly
+            if (isNaN(value)) {
+              // Check if value is boolean
+              value = value === 'true' || (value === 'false' ? false : value);
+              // Convert to milliseconds for duration
+              value = filter.name === 'duration' ? ms(value) : value;
+            } else {
+              value = Number(value);
+            }
+
+            return value;
+          });
+
+          let orFilters = value.map(buildQueryFilter('$eq', filter.name));
           if (filter.name === 'config.tags' || filter.name === 'omniboard.tags') {
-            const orFilters1 = buildQueryFilter('$in', 'config.tags')(filter.value);
-            const orFilters2 = buildQueryFilter('$in', 'omniboard.tags')(filter.value);
+            const orFilters1 = buildQueryFilter('$in', 'config.tags')(value);
+            const orFilters2 = buildQueryFilter('$in', 'omniboard.tags')(value);
             orFilters = [orFilters1, orFilters2];
           }
 


### PR DESCRIPTION
I found a bug with the advanced filters feature. When the $in operator is used with a numeric field (for example `Id`), the values are passed to the server as a string rather than a `Number`. This means it is impossible to filter IDs with the $in operator. My changes fix this issue.

This pull request uses some existing logic that I found in the codebase:
https://github.com/vivekratnavel/omniboard/blob/master/web/src/components/RunsTable/runsTable.js#L272
It might be useful to move this logic to a new function, but I am not sure where that function should be defined.

Thanks for the very useful project! :) 