### PR TITLE
Quickstart improvement: Add comment about `path` variable in  db config

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -54,6 +54,8 @@ To connect to multiple sacred databases, create a database configuration file, s
 ```
 Set the environment variable `OMNIBOARD_CONFIG=/path/to/database_config.json` before running omniboard.
 
+Then access the databases at `localhost:9000/db1` and `localhost:9000/db2`. You can configure these paths with the `path` entry in the config above.
+
 For basic authentication, start omniboard with the `-u` option:
 
 ```bash


### PR DESCRIPTION
The `path` entry was unfortunately not documented so it took me quite some time and finding this [issue](https://github.com/vivekratnavel/omniboard/issues/77) to figure this out.